### PR TITLE
Update docker-guide.md volume syntax error

### DIFF
--- a/installation/docker-guide.md
+++ b/installation/docker-guide.md
@@ -40,11 +40,17 @@ services:
 Put this file in an empty folder and run `docker-compose up`. TheHive is exposed on 9000/tcp port and Cortex on
 9001/tcp. These ports can be changed by modifying the `docker-compose` file.
 
-You can specify a custom `application.conf` file by adding the line
-`volume: /path/to/application.conf:/etc/thehive/application.conf` in `thehive` section.
+You can specify a custom `application.conf` file by adding the lines, in `thehive` section:
+```
+volumes: - /path/to/application.conf:/etc/thehive/application.conf
+```
 
-You should define where the data (i.e. the ElasticSearch database) will be stored in your server by adding the line
-`volume: /path/to/data:/usr/share/elasticsearch/data` in `elasticsearch` section.
+You should define where the data (i.e. the ElasticSearch database) will be stored in your server by adding the lines, in `elasticsearch` section:
+```
+volumes: 
+   - /path/to/data:/usr/share/elasticsearch/data
+```
+
 
 ### Manual Installation of ElasticSearch
 

--- a/installation/docker-guide.md
+++ b/installation/docker-guide.md
@@ -42,13 +42,14 @@ Put this file in an empty folder and run `docker-compose up`. TheHive is exposed
 
 You can specify a custom `application.conf` file by adding the lines, in `thehive` section:
 ```
-volumes: - /path/to/application.conf:/etc/thehive/application.conf
+volumes: 
+    - /path/to/application.conf:/etc/thehive/application.conf
 ```
 
 You should define where the data (i.e. the ElasticSearch database) will be stored in your server by adding the lines, in `elasticsearch` section:
 ```
 volumes: 
-   - /path/to/data:/usr/share/elasticsearch/data
+    - /path/to/data:/usr/share/elasticsearch/data
 ```
 
 


### PR DESCRIPTION
On the docker-compose configuration file, volume keyword is not recognized (version 1.13.0).
For the same purpose, the keyword "volumes" should be used instead : https://docs.docker.com/compose/compose-file/#volumes