### PR TITLE
Cortex job api documentation

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -11,3 +11,4 @@ TheHive exposes REST APIs through JSON over HTTP.
 - [Task](task.md)
 - [Log](log.md)
 - [User](user.md)
+- [Connectors](connectors)

--- a/api/connectors/README.md
+++ b/api/connectors/README.md
@@ -1,0 +1,7 @@
+# Connectors API
+
+TheHive offers an API to manipulate its various connectors
+
+- [Cortext](cortex)
+- [MISP](misp)
+- [Metrics](metrics)

--- a/api/connectors/README.md
+++ b/api/connectors/README.md
@@ -2,6 +2,6 @@
 
 TheHive offers an API to manipulate its various connectors
 
-- [Cortext](cortex)
+- [Cortex](cortex)
 - [MISP](misp)
 - [Metrics](metrics)

--- a/api/connectors/cortex/README.md
+++ b/api/connectors/cortex/README.md
@@ -1,0 +1,7 @@
+# Cortex manipulation through TheHive
+
+Cortex can be manipulated through TheHive with JSON over HTTP
+
+- [Job](job.md)
+- [Analyzer](analyzer.md)
+- [Report](report.md)

--- a/api/connectors/cortex/job.md
+++ b/api/connectors/cortex/job.md
@@ -1,0 +1,35 @@
+# Job
+
+## Model definition
+
+Required attributes:
+- `analyzerId` (string): identifier of the analyzer used by the job
+- `status` (enumeration): status of the job (`InProgress`, `Success`, `Failure`) **default=`InProgress`**
+- `artifactId` (string): identifier of the artifact to analyze
+- `startDate` (date): job start date
+
+Optional attributes:
+- `endDate` (date): job end date
+- `report` (string): raw content of the report sent back by the analyzer
+- `cortexId` (string): identifier of the cortex server
+- `cortexJobId` (string): identifier of the job in the cortex server
+
+## Job manipulation
+
+### Job methods
+
+| HTTP Method |URI                                |Action                   |
+|-------------|-----------------------------------|-------------------------|
+|POST         | /api/connector/cortex/job         | Create a new Cortex job |
+|GET          | /api/connector/cortex/job/:jobId  | Get a cortex job        |
+|POST         | /api/connector/cortex/job/_search | Search for cortex jobs  |
+
+### Create a new Cortex job
+Creating a new job can be done by performing the following query
+```
+POST  /api/connector/cortex/job
+```
+Parameters:
+- `cortexId`: identifier of the Cortex server
+- `artifactId`: identifier of the artifact as found with an artifact search
+- `analyzerId`: name of the analyzer used by the job


### PR DESCRIPTION
The documentation was not explaining how we could interact with the API to trigger Cortex jobs. I wrote a few lines about Cortex jobs and how to create one (in fact, only the part that I tested) and I set a base structure for future documentation about connectors.

I hope this is to your liking.

This closes CERT-BDF/TheHive#308.